### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/doc/utils/checkfiledocs.py
+++ b/doc/utils/checkfiledocs.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import os.path
 import string
@@ -52,8 +54,8 @@ def printError( f, message ):
     global currentFile
     if f != currentFile:
         currentFile = f
-        print f, ":"
-    print "\t!", message
+        print(f, ":")
+    print("\t!", message)
 
 
 for f in sourceFiles:


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.