### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@ede762b26a2de8d110bb5a3db4d7e0e080c0e917  # v1
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
     - name: Upgrade VC Project File
       # We maintain our vcproj file in an old format to maintain backwards compatibility

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -49,10 +49,10 @@ jobs:
         shell: bash
     steps:
     - name: checkout PortAudio git repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
     - name: setup vcpkg
-      uses: lukka/run-vcpkg@v7
+      uses: lukka/run-vcpkg@8a5116de2b552d6fc8894e9774aacaf2e5db4823  # v7
       if: ${{ matrix.vcpkg_triplet }} != null
       with:
         vcpkgDirectory: ${{ github.workspace }}/../vcpkg

--- a/.github/workflows/autotools_msys2.yml
+++ b/.github/workflows/autotools_msys2.yml
@@ -32,9 +32,9 @@ jobs:
         shell: msys2 {0}
     steps:
     - name: checkout PortAudio git repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
     - name: setup msys2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d  # v2
       with:
         msystem: UCRT64
         update: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,21 +66,21 @@ jobs:
       cmake_build_type: RelWithDebInfo
     steps:
     - name: Checkout PortAudio Git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
     - name: "Install dependencies [Ubuntu]"
       run: |
         sudo apt-get update
         sudo apt-get install libasound2-dev libpulse-dev libsndio-dev ${{ matrix.dependencies_extras }}
       if: matrix.os == 'ubuntu-latest'
     - name: "Set up ASIO SDK cache [Windows/MinGW]"
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
       if: matrix.asio_sdk_cache_path != null
       with:
         path: ${{ matrix.asio_sdk_cache_path }}
         key: ${{ hashFiles('.github/asiosdk-version.txt') }}
 
     - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7  # v11
       if: ${{ matrix.vcpkg_triplet }} != null
       with:
         vcpkgDirectory: ${{ github.workspace }}/../vcpkg

--- a/.github/workflows/compare_def_files.yml
+++ b/.github/workflows/compare_def_files.yml
@@ -9,8 +9,8 @@ jobs:
     name: Ubuntu
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
       with:
         python-version: '3.x'
     - name: Run the pa_compare_def_files.py script

--- a/.github/workflows/whitelint.yml
+++ b/.github/workflows/whitelint.yml
@@ -9,8 +9,8 @@ jobs:
     name: Ubuntu
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
       with:
         python-version: '3.x'
     - name: Run the pa_whitelint.py script


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).