### PR TITLE
ci: SHA-pin actions and harden workflow permissions

### DIFF
--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -2,6 +2,9 @@ name: MSBuild MSVC Project File CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: ./msvc/portaudio.sln
@@ -22,9 +25,9 @@ jobs:
 
     steps:
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@ede762b26a2de8d110bb5a3db4d7e0e080c0e917 # v1
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     - name: Upgrade VC Project File
       # We maintain our vcproj file in an old format to maintain backwards compatibility

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   # GitHub CI Actions-specific environment variables:
 
@@ -49,10 +52,10 @@ jobs:
         shell: bash
     steps:
     - name: checkout PortAudio git repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     - name: setup vcpkg
-      uses: lukka/run-vcpkg@v7.6
+      uses: lukka/run-vcpkg@8a5116de2b552d6fc8894e9774aacaf2e5db4823 # v7.6
       if: ${{ matrix.vcpkg_triplet }} != null
       with:
         vcpkgDirectory: ${{ github.workspace }}/../vcpkg

--- a/.github/workflows/autotools_msys2.yml
+++ b/.github/workflows/autotools_msys2.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   # GitHub CI Actions-specific environment variables:
 
@@ -32,9 +35,9 @@ jobs:
         shell: msys2 {0}
     steps:
     - name: checkout PortAudio git repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: setup msys2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
       with:
         msystem: UCRT64
         update: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,9 @@ name: CMake build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -66,21 +69,21 @@ jobs:
       cmake_build_type: RelWithDebInfo
     steps:
     - name: Checkout PortAudio Git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: "Install dependencies [Ubuntu]"
       run: |
         sudo apt-get update
         sudo apt-get install libasound2-dev libpulse-dev libsndio-dev ${{ matrix.dependencies_extras }}
       if: matrix.os == 'ubuntu-latest'
     - name: "Set up ASIO SDK cache [Windows/MinGW]"
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       if: matrix.asio_sdk_cache_path != null
       with:
         path: ${{ matrix.asio_sdk_cache_path }}
         key: ${{ hashFiles('.github/asiosdk-version.txt') }}
 
     - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11
       if: ${{ matrix.vcpkg_triplet }} != null
       with:
         vcpkgDirectory: ${{ github.workspace }}/../vcpkg

--- a/.github/workflows/compare_def_files.yml
+++ b/.github/workflows/compare_def_files.yml
@@ -2,6 +2,9 @@ name: Check that PortAudio .def files are in sync
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run-pa-compare-def-files-py:
 
@@ -9,8 +12,8 @@ jobs:
     name: Ubuntu
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.x'
     - name: Run the pa_compare_def_files.py script

--- a/.github/workflows/jitsi.yml
+++ b/.github/workflows/jitsi.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ libjitsi_v2 ]
 
+permissions:
+  contents: read
+
 jobs:
   build-cmake:
     name: CMake build on ${{ matrix.os }}
@@ -17,7 +20,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: cmake
       run: cmake .
     - name: build

--- a/.github/workflows/whitelint.yml
+++ b/.github/workflows/whitelint.yml
@@ -2,6 +2,9 @@ name: Check for valid whitespace usage in PortAudio source files
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   run-pa-whitelint-dot-py:
 
@@ -9,8 +12,8 @@ jobs:
     name: Ubuntu
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.x'
     - name: Run the pa_whitelint.py script


### PR DESCRIPTION
## What

Two complementary supply-chain hardening changes to all seven `.github/workflows/*.yml` files:

1. **SHA-pin every external action.** Each `uses: <owner>/<name>@<ref>` becomes `uses: <owner>/<name>@<sha> # <ref>`.
2. **Explicit `permissions:` on every workflow.** All seven are build-only, so `contents: read` at the top is sufficient — no per-job grants needed.

## Why

### Pinning
A tag like `@v3` (or a branch like `@v11`) is mutable — the upstream maintainer can move it, and a hostile maintainer (or an attacker who's compromised the maintainer's account) can replace it with attacker code. The next CI run after that move executes the new code with whatever secrets the workflow holds.

Real precedents from 2025: CVE-2025-30066 (`tj-actions/changed-files`), CVE-2025-30067 (`reviewdog/action-setup`).

SHA-pinning resolves `@v3` (or `@v11`) once, today, and freezes the workflow at that exact commit. Future tag/branch moves can't affect us. The trailing `# v3` comment preserves the human-readable version so a reader (or Dependabot auto-bumper) knows what version is pinned.

**Note:** `lukka/run-vcpkg@v11` is a *branch*, not a tag, which makes it especially risky to leave unpinned — the upstream maintainer can rewrite it at any time without leaving an obvious audit trail.

### Permissions hardening
SHA-pinning protects the entry point. It does not protect against:
- The action invoking sub-actions or fetching code at runtime (`vcpkg`, msys2 packages, Python `pip`, CDN fetches).
- A malicious commit shipped *before* this PR's pinning timestamp.
- A compromise of the action's maintainer reaching into actions we transitively depend on.

`permissions:` caps the GITHUB_TOKEN's authority so even a fully compromised action can only do what we explicitly granted. All seven workflows here only checkout, build, and run tests — none upload artifacts, post comments, or create releases — so `contents: read` is the right floor across the board.

## Detected by

SOCmate's `gha_audit` workflow + `gha_pinning_findings` table flagged this repo (4 high-severity, 10 medium-severity findings — the largest count of the five jitsi repos in the audit).

## Notes for review

- I did not bump action versions; they're pinned to their *current* SHA. A version-bump PR is a separate concern.
- This PR is draft: please run CI before marking ready.
- The existing trailing `# v3` / `# v2` comments seen on some lines were left as-is (the script idempotently re-applies them when needed).

## Test plan

- [ ] All seven workflows trigger as expected (push/PR).
- [ ] `cmake.yml` matrix builds (Ubuntu/MinGW/MSVC/macOS) all complete — vcpkg setup is a likely failure point if the SHA pinning misses something.
- [ ] No "permission denied" errors from any action.
- [ ] Re-run SOCmate's `gha pinning` audit after merge — this repo's high-severity count should drop to zero.
